### PR TITLE
Fix Gulp vendor path

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -48,8 +48,8 @@ const options = {
 const rootPath = upath.normalizeSafe(argv.rootPath);
 const adminRootPath = upath.joinSafe(rootPath, 'admin');
 const vendorPath = upath.normalizeSafe(argv.vendorPath || '.');
-const vendorAdminPath = vendorPath === '.' ? '.' : upath.joinSafe(vendorPath, 'admin-bundle');
-const vendorUiPath = vendorPath === '.' ? '../UiBundle/' : upath.joinSafe(vendorPath, 'ui-bundle');
+const vendorAdminPath = vendorPath === '.' ? '.' : upath.joinSafe(vendorPath, 'sylius/admin-bundle');
+const vendorUiPath = vendorPath === '.' ? '../UiBundle/' : upath.joinSafe(vendorPath, 'sylius/ui-bundle');
 const nodeModulesPath = upath.normalizeSafe(argv.nodeModulesPath);
 
 const paths = {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -48,8 +48,8 @@ const options = {
 const rootPath = upath.normalizeSafe(argv.rootPath);
 const adminRootPath = upath.joinSafe(rootPath, 'admin');
 const vendorPath = upath.normalizeSafe(argv.vendorPath || '.');
-const vendorAdminPath = vendorPath === '.' ? '.' : upath.joinSafe(vendorPath, 'AdminBundle');
-const vendorUiPath = vendorPath === '.' ? '../UiBundle/' : upath.joinSafe(vendorPath, 'UiBundle');
+const vendorAdminPath = vendorPath === '.' ? '.' : upath.joinSafe(vendorPath, 'admin-bundle');
+const vendorUiPath = vendorPath === '.' ? '../UiBundle/' : upath.joinSafe(vendorPath, 'ui-bundle');
 const nodeModulesPath = upath.normalizeSafe(argv.nodeModulesPath);
 
 const paths = {


### PR DESCRIPTION
When requiring this bundle directly, yarn gulp fails because the paths are broken